### PR TITLE
Update curl/tar command

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -7,7 +7,8 @@ MRuby::Gem::Specification.new('mruby-zlib') do |spec|
     spec.cc.defines << 'HAVE_UNISTD_H' if build.toolchains.include? 'gcc'
 
     file "#{dir}/zlib" do
-      sh "curl -s --fail --retry 3 --retry-delay 1 http://zlib.net/zlib-1.2.11.tar.gz | tar xzC . && mv zlib-1.2.11 #{dir}/zlib"
+      sh 'curl -L --fail --retry 3 --retry-delay 1 http://zlib.net/zlib-1.2.11.tar.gz -s -o - | tar zxf -'
+      mv 'zlib-1.2.11', "#{dir}/zlib"
     end
 
     Rake::Task["#{dir}/zlib"].invoke


### PR DESCRIPTION
With a newer version of tar for Windows the old command results into `tar: Error opening archive: Failed to open '\\.\tape0'`